### PR TITLE
Don't crash when a key doesn't exist

### DIFF
--- a/models/lua_state.py
+++ b/models/lua_state.py
@@ -81,8 +81,11 @@ class LuaState:
         :param value: value to set
         :return: None
         """
-        (reference, key) = self._parse_nested_path_reference(path)
-        return reference[key]
+        try:
+            (reference, key) = self._parse_nested_path_reference(path)
+            return reference[key]
+        except:
+            return None
 
     def _set_nested_key(self, path: str, value: Any) -> None:
         """

--- a/models/lua_state.py
+++ b/models/lua_state.py
@@ -81,11 +81,10 @@ class LuaState:
         :param value: value to set
         :return: None
         """
-        try:
-            (reference, key) = self._parse_nested_path_reference(path)
-            return reference[key]
-        except:
+        (reference, key) = self._parse_nested_path_reference(path)
+        if (len(reference) == 0):
             return None
+        return reference[key]
 
     def _set_nested_key(self, path: str, value: Any) -> None:
         """


### PR DESCRIPTION
This will allow loading of 'incompatible' saves, but I definitely wouldn't want to save back in this state.