### PR TITLE
Add field to edit damage reduction from God Mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,20 @@ def except_hook(cls, exception, traceback):
     sys.__excepthook__(cls, exception, traceback)
 
 
+def _easy_mode_level_from_damage_reduction(damage_reduction: int) -> int:
+    # Make sure the damage reduction is between 20-80 as that is what the game uses, out of range might not be safe
+    damage_reduction = max(20, min(80, damage_reduction))
+    easy_mode_level = (damage_reduction - 20) / 2
+    return easy_mode_level
+
+
+def _damage_reduction_from_easy_mode_level(easy_mode_level: int) -> int:
+    # Easy mode level is half the amount of damage reduction added to the base damage reduction from enabling god mode
+    # easy mode level 10 => 20 + (10 * 2) = 40% damage reduction
+    damage_reduction = (easy_mode_level * 2) + 20
+    return damage_reduction
+
+
 class App(QDialog):
     def __init__(self, application):
         super().__init__()
@@ -68,6 +82,7 @@ class App(QDialog):
         self.ambrosia_field = self.findChild(QLineEdit, "ambrosiaEdit")
         self.keys_field = self.findChild(QLineEdit, "chthonicKeyEdit")
         self.titan_blood_field = self.findChild(QLineEdit, "titanBloodEdit")
+        self.god_mode_damage_reduction_field = self.findChild(QLineEdit, "godModeDamageReductionEdit")
 
         self.hell_mode = self.findChild(QCheckBox, "hellModeCheckbox")
 
@@ -106,6 +121,7 @@ class App(QDialog):
         self.keys_field.setText(str(self.save_file.lua_state.chthonic_key))
         self.titan_blood_field.setText(str(self.save_file.lua_state.titan_blood))
         self.hell_mode.setChecked(bool(self.save_file.lua_state.hell_mode))
+        self.god_mode_damage_reduction_field.setText(str(_damage_reduction_from_easy_mode_level(self.save_file.lua_state.easy_mode_level)))
 
         self.dirty = True
         self.ui_state.setText("Loaded!")
@@ -120,6 +136,7 @@ class App(QDialog):
         self.save_file.lua_state.titan_blood = float(self.titan_blood_field.text())
         self.save_file.lua_state.hell_mode = bool(self.hell_mode.isChecked())
         self.save_file.hell_mode_enabled = bool(self.hell_mode.isChecked())
+        self.save_file.lua_state.easy_mode_level = _easy_mode_level_from_damage_reduction(float(self.god_mode_damage_reduction_field.text()))
 
         self.save_file.to_file(self.file_path)
         self.dirty = False

--- a/models/lua_state.py
+++ b/models/lua_state.py
@@ -66,6 +66,7 @@ class LuaState:
     chthonic_key = _LuaStateProperty("GameState.Resources.LockKeys", 0.0)
     titan_blood = _LuaStateProperty("GameState.Resources.SuperLockKeys", 0.0)
     hell_mode = _LuaStateProperty("GameState.Flags.HardMode", False)
+    easy_mode_level = _LuaStateProperty("GameState.EasyModeLevel", 0.0)
 
     gift_record = _LuaStateProperty("CurrentRun.GiftRecord", {})
     npc_interactions = _LuaStateProperty("CurrentRun.NPCInteractions", {})

--- a/pluto.ui
+++ b/pluto.ui
@@ -229,6 +229,28 @@
     </item>
    </layout>
   </widget>
+  <widget class="QWidget" name="formLayoutWidget_8">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>510</y>
+     <width>260</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="formLayout_9">
+    <item row="0" column="0">
+     <widget class="QLabel" name="godModeDamageReductionLabel">
+      <property name="text">
+       <string>God mode damage reduction:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="godModeDamageReductionEdit"/>
+    </item>
+   </layout>
+  </widget>
   <widget class="QWidget" name="gridLayoutWidget">
    <property name="geometry">
     <rect>


### PR DESCRIPTION
As I am not a godlike gamer I was using God Mode with Hades which is nice, but at some point it started to feel to easy so I want to reset the damage reduction a bit. Disabling God Mode seems to reset it completely and I didn't want to go that far. So I added a field to change it.

I tested with a savegame and it seems to work fine. Range is limited to 20-80% as that is what the game offers and I did not want to test what happens outside those ranges.