### PR TITLE
Add exporting of runs as csv

### DIFF
--- a/gamedata.py
+++ b/gamedata.py
@@ -1,0 +1,44 @@
+''' Contains Hades gamedata '''
+
+# Based on data in Weaponsets.lua
+HeroMeleeWeapons = {
+    "SwordWeapon": "Stygian Blade",
+    "SpearWeapon": "Eternal Spear",
+    "ShieldWeapon": "Shield of Chaos",
+    "BowWeapon": "Heart-Seeking Bow",
+    "FistWeapon": "Twin Fists of Malphon",
+    "GunWeapon": "Adamant Rail",
+}
+
+
+# Based on data from TraitData.lua
+AspectTraits = {
+    "SwordCriticalParryTrait": "Nemesis",
+    "SwordConsecrationTrait": "Arthur",
+    "ShieldRushBonusProjectileTrait": "Chaos",
+    "ShieldLoadAmmoTrait": "Beowulf",
+    # "ShieldBounceEmpowerTrait": "",
+    "ShieldTwoShieldTrait": "Zeus",
+    "SpearSpinTravel": "Guan Yu",
+    "GunGrenadeSelfEmpowerTrait": "Eris",
+    "FistVacuumTrait": "Talos",
+    "FistBaseUpgradeTrait": "Zagreus",
+    "FistWeaveTrait": "Demeter",
+    "FistDetonateTrait": "Gilgamesh",
+    "SwordBaseUpgradeTrait": "Zagreus",
+    "BowBaseUpgradeTrait": "Zagreus",
+    "SpearBaseUpgradeTrait": "Zagreus",
+    "ShieldBaseUpgradeTrait": "Zagreus",
+    "GunBaseUpgradeTrait": "Zagreus",
+    "DislodgeAmmoTrait": "Poseidon",
+    # "SwordAmmoWaveTrait": "",
+    "GunManualReloadTrait": "Hestia",
+    "GunLoadedGrenadeTrait": "Lucifer",
+    "BowMarkHomingTrait": "Chiron",
+    "BowLoadAmmoTrait": "Hera",
+    # "BowStoredChargeTrait": "",
+    "BowBondTrait": "Rama",
+    # "BowBeamTrait": "",
+    "SpearWeaveTrait": "Hades",
+    "SpearTeleportTrait": "Achilles",
+}

--- a/main.py
+++ b/main.py
@@ -198,11 +198,11 @@ class App(QDialog):
                   # Heat
                   run.get("ShrinePointsCache", ""),  # This seems to be heat
                   # Weapon
-                  self._get_weapon_from_weapons_cache(run["WeaponsCache"]),
+                  self._get_weapon_from_weapons_cache(run["WeaponsCache"]) if "WeaponsCache" in run else "",
                   # Form
-                  self._get_aspect_from_trait_cache(run['TraitCache']),
+                  self._get_aspect_from_trait_cache(run["TraitCache"]) if "TraitCache" in run else "",
                   # Run duration (seconds)
-                  run["GameplayTime"],
+                  run["GameplayTime"] if "GameplayTime" in run else "",
                   # Outcome
                   "Escaped" if run.get("Cleared", False) else "",
                   # Godmode

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from PyQt5.QtCore import QStandardPaths
 from PyQt5.QtWidgets import QFileDialog, QPushButton, QLineEdit, QMessageBox, QDialog, QLabel, QCheckBox, QWidget
 
 from models.save_file import HadesSaveFile
+import gamedata
 
 mainWin = None
 
@@ -64,6 +65,9 @@ class App(QDialog):
 
         self.save_button = self.findChild(QPushButton, "save")
         self.save_button.clicked.connect(self.write_file)
+
+        self.save_button = self.findChild(QPushButton, "export")
+        self.save_button.clicked.connect(self.export_runs_as_csv)
 
         self.exit_button = self.findChild(QPushButton, "exit")
         self.exit_button.clicked.connect(self.safe_quit)
@@ -160,6 +164,58 @@ class App(QDialog):
                 return
 
         self.app.quit()
+
+    def _get_aspect_from_trait_cache(self, trait_cache):
+        for trait in trait_cache:
+            if trait in gamedata.AspectTraits:
+                return f"Aspect of {gamedata.AspectTraits[trait]}"
+        return "Redacted"  # This is what it says in game
+
+    def _get_weapon_from_weapons_cache(self, weapons_cache):
+        for weapon_name in gamedata.HeroMeleeWeapons.keys():
+            if weapon_name in weapons_cache:
+                return gamedata.HeroMeleeWeapons[weapon_name]
+        return "Unknown weapon"
+
+    def export_runs_as_csv(self):
+        if not self.file_path:
+            self.ui_state.setText("Export failed, no savegame loaded!")
+            return
+
+        runs = self.save_file.lua_state.to_dicts()[0]["GameState"]["RunHistory"]
+        # import json
+        # with open("runs.json", "w") as f:
+        #   f.write(json.dumps(runs, indent=2))
+        # print(len(runs))
+
+        csvfilename = "runs.csv"
+
+        import csv
+        with open(csvfilename, "w", newline='') as csvfile:
+          run_writer = csv.writer(csvfile, dialect='excel')
+          run_writer.writerow(["Attempt", "Heat", "Weapon", "Form", "Elapsed time (seconds)", "Outcome", "Godmode", "Godmode damage reduction"])
+
+          for key, run in runs.items():
+              run_writer.writerow([
+                  # Attempt
+                  int(key),
+                  # Heat
+                  run.get("ShrinePointsCache", ""),  # This seems to be heat
+                  # Weapon
+                  self._get_weapon_from_weapons_cache(run["WeaponsCache"]),
+                  # Form
+                  self._get_aspect_from_trait_cache(run['TraitCache']),
+                  # Run duration (seconds)
+                  run["GameplayTime"],
+                  # Outcome
+                  "Escaped" if run.get("Cleared", False) else "",
+                  # Godmode
+                  "EasyModeLevel" in run,
+                  # Godmode damage reduction
+                  _damage_reduction_from_easy_mode_level(run["EasyModeLevel"]) if "EasyModeLevel" in run else ""
+                  ])
+
+        self.ui_state.setText(f"Exported to {csvfilename}")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -183,10 +183,6 @@ class App(QDialog):
             return
 
         runs = self.save_file.lua_state.to_dicts()[0]["GameState"]["RunHistory"]
-        # import json
-        # with open("runs.json", "w") as f:
-        #   f.write(json.dumps(runs, indent=2))
-        # print(len(runs))
 
         csvfilename = "runs.csv"
 

--- a/pluto.ui
+++ b/pluto.ui
@@ -43,6 +43,13 @@
       </property>
      </widget>
     </item>
+    <item>
+     <widget class="QPushButton" name="export">
+      <property name="text">
+       <string>Export runs to CSV</string>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QPushButton" name="exit">


### PR DESCRIPTION
I saw a post on reddit of a user that made some cool graphs about the Hades runs https://www.reddit.com/r/HadesTheGame/comments/jxcli3/hades_200_runs_later_a_statistical_breakdown/

That user copied the data from the game screens, but for me it seemed easier to just export it from the save file. So this pull requests adds a button to export some data from all runs to a .csv which can then easily be used in other programs.

I tried to keep it simple for now so it does not export the full outcome, just Escaped or "" as that is a bit hard to get and required including a lot of gamedata (also how to handle translations?).

I made it so it just writes to a file called "runs.csv" in the directory where the savegame editor is running from. Not sure if that is the best way. Maybe a save dialog would be better?
Initially I had it writing to the savegame dir, but that felt a bit scary.

As an example, here are the first 10 runs I did
```
Attempt,Heat,Weapon,Form,Elapsed time (seconds),Outcome,Godmode,Godmode damage reduction
1,0.0,Stygian Blade,Redacted,281.01105308532715,,False,
2,0.0,Heart-Seeking Bow,Redacted,496.92266845703125,,True,20.0
3,0.0,Stygian Blade,Redacted,479.8309326171875,,True,22.0
4,0.0,Heart-Seeking Bow,Redacted,815.796142578125,,True,24.0
5,0.0,Stygian Blade,Redacted,727.88525390625,,True,26.0
6,0.0,Eternal Spear,Redacted,859.4775390625,,True,28.0
7,0.0,Stygian Blade,Redacted,580.990234375,,True,30.0
8,0.0,Stygian Blade,Redacted,636.521484375,,True,32.0
9,0.0,Shield of Chaos,Redacted,589.28515625,,True,34.0
10,0.0,Heart-Seeking Bow,Redacted,1336.0800018310547,,True,36.0
```
and a few lines to show forms
```
23,0.0,Stygian Blade,Aspect of Nemesis,2442.99658203125,,True,62.0
24,0.0,Eternal Spear,Aspect of Zagreus,3006.5634765625,Escaped,True,64.0
```
